### PR TITLE
Realizada a tradução do post Erros da seção Erros e Exceções

### DIFF
--- a/_posts/07-01-01-Errors-and-Exceptions.md
+++ b/_posts/07-01-01-Errors-and-Exceptions.md
@@ -1,6 +1,6 @@
 ---
-title: Errors and Exceptions
+title: Erros e Exceções
 ---
 
-# Errors and Exceptions {#errors_and_exceptions_title}
+# Erros e Exceções {#errors_and_exceptions_title}
 

--- a/_posts/07-02-01-Errors.md
+++ b/_posts/07-02-01-Errors.md
@@ -2,10 +2,10 @@
 isChild: true
 ---
 
-## Errors {#errors_title}
+## Erros {#errors_title}
 
-PHP has several levels of error severity. The three most common types of messages are errors, notices and warnings. These have different levels of severity; `E_ERROR`, `E_NOTICE`, and `E_WARNING`. Errors are fatal run-time errors and are usually caused by faults in your code and need to be fixed as they'll cause PHP to stop executing. Warnings are non-fatal errors, execution of the script will not be halted. Notices are advisory messages caused by code that may or may not cause problems during the execution of the script, execution is not halted. 
+O PHP possui vários níveis de severidade de erros. Os três tipos mais comuns de mensagens são erros, avisos e advertências. Esses possuem diferentes níveis de severidade: `E_ERROR`, `E_NOTICE` e `E_WARNING`. Erros são erros fatais de tempo de execução e são geralmente causados por falhas no seu código e precisam ser corrigidos, pois eles irão fazer com que a execução do PHP seja interrompida. Advertências não são erros fatais e a execução do script não será interrompida. Avisos são mensagens indicativas causadas pelo código que podem ou não causar problemas durante a execução do script e a execução não será interrompida.
 
-Another type of error message reported at compile time is the `E_STRICT` message, these messages are used to suggest changes to your code to help ensure best interoperability and forward compatibility for your code.  
+Um outro tipo de mensagem de erro reportada em tempo de compilação é o `E_STRICT`. Essas mensagens são usadas para sugerir mudanças no seu código para ajudar a garantir uma melhor interoperabilidade e compatibilidade do seu código.
 
-* [Predefined Constants for Error Handling](http://www.php.net/manual/en/errorfunc.constants.php)
+* [Constantes Pré-definidas para Tratamento de Erros](http://www.php.net/manual/en/errorfunc.constants.php)


### PR DESCRIPTION
Realizei a tradução do post Errors

> Errors
> PHP has several levels of error severity. The three most common types of messages are errors, notices and warnings. These have different levels of severity; E_ERROR, E_NOTICE, and E_WARNING. Errors are fatal run-time errors and are usually caused by faults in your code and need to be fixed as they’ll cause PHP to stop executing. Warnings are non-fatal errors, execution of the script will not be halted. Notices are advisory messages caused by code that may or may not cause problems during the execution of the script, execution is not halted.
> 
> Another type of error message reported at compile time is the E_STRICT message, these messages are used to suggest changes to your code to help ensure best interoperability and forward compatibility for your code.
> 
> Predefined Constants for Error Handling
