### PR TITLE
CRITICAL - Bug kramdown anchor

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,7 @@
                 {% for post in site.posts reversed %}
                     {% if post.isChild and lastIsChild != true %}<ul>{% endif %}
                     {% if lastIsChild and post.isChild != true %}</ul>{% endif %}
-                    <li><a href="/#{{ post.title | downcase | replace:' ','_' | replace:'(','' | replace:')','' | replace:'.','' | replace:'-','' }}">{{ post.title }}</a>
+                    <li><a href="/#{{ post.anchor }}">{{ post.title }}</a>
                     {% assign lastIsChild = post.isChild %}
                 {% endfor %}
                 <li><a href="/#site-footer">Créditos</a></li>

--- a/_posts/01-01-01-Getting-Started.md
+++ b/_posts/01-01-01-Getting-Started.md
@@ -1,5 +1,7 @@
 ---
 title: Começando
+anchor: comecando
 ---
+
 # Começando {#comecando_title}
 

--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -1,9 +1,10 @@
 ---
 title: Use a versão estável atual (5.5)
 isChild: true
+anchor: use_a_versao_estavel_atual_55
 ---
 
-## Use a versão estável atual (5.5) {#use_a_versão_estável_atual_55_title}
+## Use a versão estável atual (5.5) {#use_a_versao_estavel_atual_55_title}
 
 Se você está começando com o PHP, certifique-se de começar com a versão estável atual do [PHP 5.5][php-release]. O PHP
 fez grandes avanços adicionando [novas funcionalidades](#language_highlights) poderosas nos últimos anos. Não deixe que

--- a/_posts/01-03-01-Built-in-Web-Server.md
+++ b/_posts/01-03-01-Built-in-Web-Server.md
@@ -1,6 +1,7 @@
 ---
 title: Servidor web embutido
 isChild: true
+anchor: servidor_web_embutido
 ---
 
 ## Servidor web embutido {#servidor_web_embutido_title}

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -1,8 +1,10 @@
 ---
+title: Instalação no Mac
 isChild: true
+anchor: instalacao_no_mac
 ---
 
-## Instalação no Mac {#mac_setup_title}
+## Instalação no Mac {#instalacao_no_mac_title}
 
 O OSX já vem com o PHP, mas ele é normalmente um pouco atrasado em relação ao último estável. O Lion vem com o
 PHP 5.3.6, Mountain Lion com o 5.3.10 e Mavericks com 5.4.17.

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -1,8 +1,10 @@
 ---
+title: Instalação no Windows
 isChild: true
+anchor: instalacao_no_windows
 ---
 
-## Instalação no Windows {#windows_setup_title}
+## Instalação no Windows {#instalacao_no_windows_title}
 
 O PHP está disponível de diversas maneiras no Windows. Você pode [baixar os binários](php-downloads) e até recentemente
 você podia usar um instalador '.msi'. O instalador não é mais suportado e parou no PHP 5.3.0.

--- a/_posts/01-06-01-Vagrant.md
+++ b/_posts/01-06-01-Vagrant.md
@@ -1,5 +1,7 @@
 ---
+title: Vagrant
 isChild: true
+anchor: vagrant
 ---
 
 ## Vagrant {#vagrant_title}

--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -1,7 +1,9 @@
 ---
 title: Guia de estilo de código
+anchor: guia_de_estilo_de_codigo
 ---
-# Guia de estilo de código {#guia_de_estilo_de_código_title}
+
+# Guia de estilo de código {#guia_de_estilo_de_codigo_title}
 
 A comunidade PHP é grande e diversa, composta por inúmeras bibliotecas, frameworks e componentes. É comum para
 desenvolvedores PHP escolher vários destes e combiná-los em um único projeto. É importante que código PHP siga (o

--- a/_posts/03-01-01-Language-Highlights.md
+++ b/_posts/03-01-01-Language-Highlights.md
@@ -1,4 +1,6 @@
 ---
 title: Destaques da linguagem
+anchor: destaques_da_linguagem
 ---
+
 # Destaques da linguagem {#destaques_da_linguagem_title}

--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -1,9 +1,10 @@
 ---
 title: Paradigmas de programação
 isChild: true
+anchor: paradigmas_de_programacao
 ---
 
-## Paradigmas de programação {#paradigmas_de_programação_title}
+## Paradigmas de programação {#paradigmas_de_programacao_title}
 
 O PHP é uma linguagem dinâmica e flexível, que suporta uma variedade de técnicas de programação. Ele evoluiu
 drasticamente com o passar dos anos, notavelmente adicionando um sólido modelo de orientação a objetos no PHP 5.0 

--- a/_posts/03-03-01-Namespaces.md
+++ b/_posts/03-03-01-Namespaces.md
@@ -1,5 +1,7 @@
 ---
+title: Namespaces
 isChild: true
+anchor: namespaces
 ---
 
 ## Namespaces {#namespaces_title}

--- a/_posts/03-04-01-Standard-PHP-Library.md
+++ b/_posts/03-04-01-Standard-PHP-Library.md
@@ -1,6 +1,7 @@
 ---
-title:   Standard PHP Library
+title: Standard PHP Library
 isChild: true
+anchor: standard_php_library
 ---
 
 ## Standard PHP Library {#standard_php_library_title}

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -1,6 +1,7 @@
 ---
 title: Interface de Linha de Comando
 isChild: true
+anchor: interface_de_linha_de_comando
 ---
 
 ## Interface de Linha de Comando {#interface_de_linha_de_comando_title}

--- a/_posts/03-06-01-XDebug.md
+++ b/_posts/03-06-01-XDebug.md
@@ -1,6 +1,7 @@
 ---
 title: XDebug
 isChild: true
+anchor: xdebug
 ---
 
 ## XDebug {#xdebug_title}

--- a/_posts/04-01-01-Dependency-Management.md
+++ b/_posts/04-01-01-Dependency-Management.md
@@ -1,7 +1,9 @@
 ---
 title: Gerenciamento de Dependência
+anchor: gerenciamento_de_dependencia
 ---
-# Gerenciamento de Dependência {#gerenciamento_de_dependência_title}
+
+# Gerenciamento de Dependência {#gerenciamento_de_dependencia_title}
 
 Existem toneladas de bibliotecas PHP, frameworks, e componentes para você escolher. Seu projeto provavelmente irá
 usar muitos deles - eles são as dependências do projeto. Até recentemente, o PHP não possuia uma boa forma de

--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -1,6 +1,7 @@
 ---
 title: Composer e Packagist
 isChild: true
+anchor: composer_e_packagist
 ---
 
 ## Composer e Packagist {#composer_e_packagist_title}

--- a/_posts/04-03-01-PEAR.md
+++ b/_posts/04-03-01-PEAR.md
@@ -1,6 +1,7 @@
 ---
 title: PEAR
 isChild: true
+anchor: pear
 ---
 
 ## PEAR {#pear_title}

--- a/_posts/05-01-01-Coding-Practices.md
+++ b/_posts/05-01-01-Coding-Practices.md
@@ -1,5 +1,6 @@
 ---
 title: Práticas de Codificação
+anchor: praticas_de_codificacao
 ---
 
-# Práticas de Codificação {#práticas_de_codificação_title}
+# Práticas de Codificação {#praticas_de_codificacao_title}

--- a/_posts/05-02-01-The-Basics.md
+++ b/_posts/05-02-01-The-Basics.md
@@ -1,9 +1,10 @@
 ---
 title: O Básico
 isChild: true
+anchor: o_basico
 ---
 
-## O Básico {#o_básico_title}
+## O Básico {#o_basico_title}
 
 PHP é uma grande linguagem que permite a programadores de todos os níveis produzirem código, não apenas rapidamente,
 mas eficientemente. Entretando enquanto se avança na linguagem, nós frequentemente esquecemos do básico que tinhamos

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -1,9 +1,10 @@
 ---
 title: Data e Horário
 isChild: true
+anchor: data_e_horario
 ---
 
-## Data e Horário {#data_e_horário_title}
+## Data e Horário {#data_e_horario_title}
 
 O PHP tem uma classe chamada DateTime para ajudar você com leitura, escrita, comparações e cálculos com datas e
 horários. Existem muitas funções no PHP relacionadas a datas e horários além da DateTime, mas ela fornece uma boa

--- a/_posts/05-04-01-Design-Patterns.md
+++ b/_posts/05-04-01-Design-Patterns.md
@@ -1,6 +1,7 @@
 ---
 title: Design Patterns
 isChild: true
+anchor: design_patterns
 ---
 
 ## Design Patterns {#design_patterns_title}

--- a/_posts/06-01-01-Dependency-Injection.md
+++ b/_posts/06-01-01-Dependency-Injection.md
@@ -1,5 +1,6 @@
 ---
 title: Dependency Injection
+anchor: dependency_injection
 ---
 
 # Dependency Injection (Injeção de Dependência) {#dependency_injection_title}

--- a/_posts/06-02-01-Basic-Concept.md
+++ b/_posts/06-02-01-Basic-Concept.md
@@ -1,9 +1,10 @@
 ---
 title: Conceito Básico
 isChild: true
+anchor: conceito_basico
 ---
 
-## Conceito Básico {#conceito_básico_title}
+## Conceito Básico {#conceito_basico_title}
 
 Demostraremos o conceito com um simples exemplo.
 

--- a/_posts/06-03-01-Complex-Problem.md
+++ b/_posts/06-03-01-Complex-Problem.md
@@ -1,6 +1,7 @@
 ---
 title: Problema Complexo
 isChild: true
+anchor: problema_complexo
 ---
 
 ## Problema Complexo {#problema_complexo_title}

--- a/_posts/06-04-01-Containers.md
+++ b/_posts/06-04-01-Containers.md
@@ -1,5 +1,7 @@
 ---
+title: Containers
 isChild: true
+anchor: containers
 ---
 
 ## Containers {#containers_title}

--- a/_posts/06-05-01-Further-Reading.md
+++ b/_posts/06-05-01-Further-Reading.md
@@ -1,6 +1,7 @@
 ---
 title: Leitura Adicional
 isChild: true
+anchor: leitura_adicional
 ---
 
 ## Leitura Adicional {#leitura_adicional_title}

--- a/_posts/07-01-01-Databases.md
+++ b/_posts/07-01-01-Databases.md
@@ -1,5 +1,6 @@
 ---
 title: Banco de Dados
+anchor: banco_de_dados
 ---
 
 # Bancos de Dados {#banco_de_dados_title}

--- a/_posts/08-01-01-Errors-and-Exceptions.md
+++ b/_posts/08-01-01-Errors-and-Exceptions.md
@@ -1,6 +1,7 @@
 ---
 title: Erros e Exceções
+anchor: erros_e_excecoes
 ---
 
-# Erros e Exceções {#erros_e_exceções_title}
+# Erros e Exceções {#erros_e_excecoes_title}
 

--- a/_posts/08-02-01-Errors.md
+++ b/_posts/08-02-01-Errors.md
@@ -1,6 +1,7 @@
 ---
 title: Erros
 isChild: true
+anchor: erros
 ---
 
 ## Erros {#erros_title}

--- a/_posts/08-03-01-Exceptions.md
+++ b/_posts/08-03-01-Exceptions.md
@@ -1,9 +1,10 @@
 ---
 title: Exceções
 isChild: true
+anchor: excecoes
 ---
 
-## Exceções {#exceções_title}
+## Exceções {#excecoes_title}
 
 Exceções são uma parte padrão da maioria das linguagens populares, mas elas sao frequentemente negligenciadas pelos
 programadores de PHP. Linguagens como Ruby usam pesadamente o sistema de Exceções, então sempre que algo de errado

--- a/_posts/09-01-01-Security.md
+++ b/_posts/09-01-01-Security.md
@@ -1,4 +1,6 @@
 ---
 title: Segurança
+anchor: seguranca
 ---
-# Segurança {#segurança_title}
+
+# Segurança {#seguranca_title}

--- a/_posts/09-02-01-Web-Application-Security.md
+++ b/_posts/09-02-01-Web-Application-Security.md
@@ -1,9 +1,10 @@
 ---
 title: Segurança em uma Aplicação Web
 isChild: true
+anchor: seguranca_em_uma_aplicacao_web
 ---
 
-## Segurança em uma Aplicação Web {#segurança_em_uma_aplicação_web_title}
+## Segurança em uma Aplicação Web {#seguranca_em_uma_aplicacao_web_title}
 
 Existem pessoas ruins prontas e dispostas a invadir sua aplicação web. É importante que você tome as medidas
 necessárias para reforçar a segurança da sua aplicação web. Felizmente, o pessoal bacana da

--- a/_posts/09-03-01-Password-Hashing.md
+++ b/_posts/09-03-01-Password-Hashing.md
@@ -1,6 +1,7 @@
 ---
 title: Hash de Senhas
 isChild: true
+anchor: hash_de_senhas
 ---
 
 ## Hash de Senhas {#hash_de_senhas_title}

--- a/_posts/09-04-01-Data-Filtering.md
+++ b/_posts/09-04-01-Data-Filtering.md
@@ -1,6 +1,7 @@
 ---
 title: Filtro de Dados
 isChild: true
+anchor: filtro_de_dados
 ---
 
 ## Filtro de Dados {#filtro_de_dados_title}

--- a/_posts/09-05-01-Configuration-Files.md
+++ b/_posts/09-05-01-Configuration-Files.md
@@ -1,9 +1,10 @@
 ---
 title: Arquivos de Configuração
 isChild: true
+anchor: arquivos_de_configuracao
 ---
 
-## Arquivos de Configuração {#arquivos_de_configuração_title}
+## Arquivos de Configuração {#arquivos_de_configuracao_title}
 
 Quando criar arquivos de configuração para suas aplicações, as melhores práticas recomendam que um dos seguintes métodos
 seja seguido:

--- a/_posts/09-06-01-Register-Globals.md
+++ b/_posts/09-06-01-Register-Globals.md
@@ -1,6 +1,7 @@
 ---
 title: Register Globals
 isChild: true
+anchor: register_globals
 ---
 
 ## Register Globals {#register_globals_title}

--- a/_posts/09-07-01-Error-Reporting.md
+++ b/_posts/09-07-01-Error-Reporting.md
@@ -1,9 +1,10 @@
 ---
 title: Relatório de Erros
 isChild: true
+anchor: relatorio_de_erros
 ---
 
-## Relatório de Erros {#relatório_de_erros_title}
+## Relatório de Erros {#relatorio_de_erros_title}
 
 O registro de erros pode ser útil para encontrar pontos problemáticos em sua aplicação, mas isso também pode expor
 informações sobre a estrutura de sua aplicação para o mundo exterior. Para proteger efetivamente sua aplicação dos

--- a/_posts/10-01-01-Testing.md
+++ b/_posts/10-01-01-Testing.md
@@ -1,5 +1,6 @@
 ---
 title: Testes
+anchor: testes
 ---
 
 # Testes {#testes_title}

--- a/_posts/10-02-01-Test-Driven-Development.md
+++ b/_posts/10-02-01-Test-Driven-Development.md
@@ -1,6 +1,7 @@
 ---
 title: Desenvolvimento Guiado por Testes
 isChild: true
+anchor: desenvolvimento_guiado_por_testes
 ---
 
 ## Desenvolvimento Guiado por Testes {#desenvolvimento_guiado_por_testes_title}

--- a/_posts/10-03-01-Behavior-Driven-Development.md
+++ b/_posts/10-03-01-Behavior-Driven-Development.md
@@ -1,6 +1,7 @@
 ---
 title: Desenvolvimento Guiado por Comportamentos
 isChild: true
+anchor: desenvolvimento_guiado_por_comportamentos
 ---
 
 ## Desenvolvimento Guiado por Comportamentos {#desenvolvimento_guiado_por_comportamentos_title}

--- a/_posts/10-04-01-Complementary-Testing-Tools.md
+++ b/_posts/10-04-01-Complementary-Testing-Tools.md
@@ -1,6 +1,7 @@
 ---
 title: Ferramentas Complementares para Testes
 isChild: true
+anchor: ferramentas_complementares_para_testes
 ---
 
 ## Ferramentas Complementares para Testes {#ferramentas_complementares_para_testes_title}

--- a/_posts/11-01-01-Servers-and-Deployment.md
+++ b/_posts/11-01-01-Servers-and-Deployment.md
@@ -1,7 +1,8 @@
 ---
 title: Servidores e Publicação
+anchor: servidores_e_publicacao
 ---
 
-# Servidores e Publicação {#servidores_e_publicação_title}
+# Servidores e Publicação {#servidores_e_publicacao_title}
 
 As aplicações PHP podem ser publicadas e executadas em servidores web de produção de diversas formas.

--- a/_posts/11-02-01-Platform-as-a-Service.md
+++ b/_posts/11-02-01-Platform-as-a-Service.md
@@ -1,9 +1,10 @@
 ---
 title: Plataforma como Serviço (PaaS)
 isChild: true
+anchor: plataforma_como_servico_pass
 ---
 
-## Plataforma como Serviço (PaaS) {#plataforma_como_serviço_paas_title}
+## Plataforma como Serviço (PaaS) {#plataforma_como_servico_paas_title}
 
 O PaaS fornece o sistema e a arquitetura de rede necessários para executar aplicações PHP na web. Isso significa não
 precisar de quase nenhuma configuração para publicar aplicações ou frameworks PHP.

--- a/_posts/11-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/11-03-01-Virtual-or-Dedicated-Servers.md
@@ -1,6 +1,7 @@
 ---
 title: Servidores Virtuais ou Dedicados
 isChild: true
+anchor: servidores_virtuais_ou_dedicados
 ---
 
 ## Servidores Virtuais ou Dedicados {#servidores_virtuais_ou_dedicados_title}

--- a/_posts/11-04-01-Shared-Servers.md
+++ b/_posts/11-04-01-Shared-Servers.md
@@ -1,6 +1,7 @@
 ---
 title: Servidores Compartilhados
 isChild: true
+anchor: servidores_compatilhados
 ---
 
 ## Servidores Compartilhados {#servidores_compartilhados_title}

--- a/_posts/11-05-01-Building-your-Application.md
+++ b/_posts/11-05-01-Building-your-Application.md
@@ -1,9 +1,10 @@
 ---
 title: Compilando e Implementando sua Aplicação
 isChild: true
+anchor: compilando_e_implementando_sua_aplicacao
 ---
 
-## "Compilando" e Implementando sua Aplicação {#compilando_e_implementando_sua_aplicação_title}
+## "Compilando" e Implementando sua Aplicação {#compilando_e_implementando_sua_aplicacao_title}
 
 Se você se pegar fazendo alterações manuais no seu esquema do banco de dados ou rodando seus testes manualmente antes de
 alterar seus arquivos (manualmente), pense duas vezes! A cada tarefa manual adicional necessária para implementar uma

--- a/_posts/12-01-01-Caching.md
+++ b/_posts/12-01-01-Caching.md
@@ -1,5 +1,6 @@
 ---
 title: Cache
+anchor: cache
 ---
 
 # Cache {#cache_title}

--- a/_posts/12-02-01-Bytecode-Cache.md
+++ b/_posts/12-02-01-Bytecode-Cache.md
@@ -1,6 +1,7 @@
 ---
 title: Cache de Bytecode
 isChild: true
+anchor: cache_de_bytecode
 ---
 
 ## Cache de Bytecode {#cache_de_bytecode_title}

--- a/_posts/12-03-01-Object-Caching.md
+++ b/_posts/12-03-01-Object-Caching.md
@@ -1,6 +1,7 @@
 ---
 title: Cache de Objetos
 isChild: true
+anchor: cache_de_objetos
 ---
 
 ## Cache de Objetos {#cache_de_objetos_title}

--- a/_posts/13-01-01-Resources.md
+++ b/_posts/13-01-01-Resources.md
@@ -1,5 +1,6 @@
 ---
 title: Recursos
+anchor: recursos
 ---
 
 # Recursos {#recursos_title}

--- a/_posts/13-02-01-Frameworks.md
+++ b/_posts/13-02-01-Frameworks.md
@@ -1,6 +1,7 @@
 ---
 title: Frameworks
 isChild: true
+anchor: frameworks
 ---
 
 ## Frameworks {#frameworks_title}

--- a/_posts/13-03-01-Components.md
+++ b/_posts/13-03-01-Components.md
@@ -1,6 +1,7 @@
 ---
 title: Componentes
 isChild: true
+anchor: componentes
 ---
 
 ## Componentes {#componentes_title}

--- a/_posts/14-01-01-Community.md
+++ b/_posts/14-01-01-Community.md
@@ -1,5 +1,6 @@
 ---
 title: Comunidade
+anchor: comunidade
 ---
 
 # Comunidade {#comunidade_title}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ description: "Uma referência rápida de melhores práticas de PHP, renomados pa
     {% if post.isChild != true and loop.first != true %}
     {{ backtotop|markdownify }}
     {% endif %}
-    <div id="{{ post.title | downcase | replace:' ','_' | replace:'(','' | replace:')','' | replace:'.','' | replace:'-','' }}">
+    <div id="{{ post.anchor }}">
     {{ post.content }}
     </div>
 {% endfor %}


### PR DESCRIPTION
@klaussilveira @rogeriopradoj @pauloelr 

A atualização do maruku para o kramdown gerou um problema com relação aos anchor por conta das acentuações que não são reconhecidas.

Ex.: [Versão pt_BR atual e quebrada](http://br.phptherightway.com/#começando)

Simplesmente remover os acentos não resolve o problema, pois desta forma quebraria o menu _highlighting_ e ainda sim não funcionaria os anchor.

Criei então no front matter uma opção chamada anchor - que é o título do post mas sem nenhuma acentuação, espaços ou caracteres especiais - em todos os arquivos de _posts

Utilizei depois esta opção no lugar de title dos links.

Adicionando uma explicação, o que está definido como **anchor** é utilizado para a navegação interna na página enquanto que o conteúdo de **#{xxxxx_title}** é utilizado para o _highlighting_

Esta foi a mesma opção utilizada pelo repo oficial, ex.:
- [getting_started.md](https://raw.githubusercontent.com/codeguy/php-the-right-way/gh-pages/_posts/01-01-01-Getting-Started.md)
- [index.html](https://github.com/codeguy/php-the-right-way/blob/gh-pages/index.html#L14)
- [default.html](https://github.com/codeguy/php-the-right-way/blob/gh-pages/_layouts/default.html#L51)

O ultimo build quebrou a navegação interna do site e este PR tem o propósito de corrigí-lo.

Este PR foi testado localmente e está pronto para o merge e close.
