### PR TITLE
Alteração nos links para o manual do php para pt br

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -12,4 +12,4 @@ a pequena diferença entre os números decimais das versões 5.2 a 5.5 o enganem
 procurando por uma função ou seu uso, a documentação no [php.net][php-docs] terá a resposta.
 
 [php-release]: http://www.php.net/downloads.php
-[php-docs]: http://www.php.net/manual/en/
+[php-docs]: http://www.php.net/manual/pt_BR/

--- a/_posts/01-03-01-Built-in-Web-Server.md
+++ b/_posts/01-03-01-Built-in-Web-Server.md
@@ -13,4 +13,4 @@ PHP 5.4+). Para iniciar o servidor, execute o seguinte comando no seu terminal d
 
 * [Saiba mais sobre o servidor web embutido, pela linha de comando][cli-server]
 
-[cli-server]: http://www.php.net/manual/en/features.commandline.webserver.php
+[cli-server]: http://www.php.net/manual/pt_BR/features.commandline.webserver.php

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -18,8 +18,8 @@ Outra opção é [compilar você mesmo][mac-compile]. Nesse caso, certifique-se 
 
 Para um pacote LAMP completo com GUI, tente o [MAMP][mamp-downloads] ou [XAMPP][xampp].
 
-[mac-package-managers]: http://www.php.net/manual/en/install.macosx.packages.php
-[mac-compile]: http://www.php.net/manual/en/install.macosx.compile.php
+[mac-package-managers]: http://www.php.net/manual/pt_BR/install.macosx.packages.php
+[mac-compile]: http://www.php.net/manual/pt_BR/install.macosx.compile.php
 [xcode-gcc-substitution]: https://github.com/kennethreitz/osx-gcc-installer
 [apple-developer]: https://developer.apple.com/downloads
 [mamp-downloads]: http://www.mamp.info/en/downloads/index.html

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -19,7 +19,7 @@ Outra opção é [compilar você mesmo][mac-compile]. Nesse caso, certifique-se 
 Para um pacote LAMP completo com GUI, tente o [MAMP][mamp-downloads] ou [XAMPP][xampp].
 
 [mac-package-managers]: http://www.php.net/manual/pt_BR/install.macosx.packages.php
-[mac-compile]: http://www.php.net/manual/pt_BR/install.macosx.compile.php
+[mac-compile]: http://www.php.net/manual/en/install.macosx.compile.php
 [xcode-gcc-substitution]: https://github.com/kennethreitz/osx-gcc-installer
 [apple-developer]: https://developer.apple.com/downloads
 [mamp-downloads]: http://www.mamp.info/en/downloads/index.html

--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -42,7 +42,7 @@ possam trabalhar nessa base de código.
 [psr1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
 [psr2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 [psr4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
-[pear-cs]: http://pear.php.net/manual/en/standards.php
+[pear-cs]: http://pear.php.net/manual/pt_BR/standards.php
 [zend-cs]: http://framework.zend.com/wiki/display/ZFDEV2/Coding+Standards
 [phpcs]: http://pear.php.net/package/PHP_CodeSniffer/
 [st-cs]: https://github.com/benmatselby/sublime-phpcs

--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -55,9 +55,9 @@ desenvolvedores alterem o comportamento das classes. Desenvolvedores Ruby costum
 [oop]: http://www.php.net/manual/pt_BR/language.oop5.php
 [anonymous-functions]: http://www.php.net/manual/pt_BR/functions.anonymous.php
 [closure-class]: http://php.net/manual/pt_BR/class.closure.php
-[callables]: http://php.net/manual/pt_BR/language.types.callable.php
+[callables]: http://php.net/manual/en/language.types.callable.php
 [magic-methods]: http://php.net/manual/pt_BR/language.oop5.magic.php
 [reflection]: http://www.php.net/manual/pt_BR/intro.reflection.php
-[traits]: http://www.php.net/traits
+[traits]: http://br1.php.net/traits
 [call-user-func-array]: http://php.net/manual/pt_BR/function.call-user-func-array.php
 [closures-rfc]: https://wiki.php.net/rfc/closures

--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -50,14 +50,14 @@ desenvolvedores alterem o comportamento das classes. Desenvolvedores Ruby costum
 * [Leia sobre Métodos Mágicos][magic-methods]
 * [Leia sobre Reflexão][reflection]
 
-[namespaces]: http://php.net/manual/en/language.namespaces.php
-[overloading]: http://php.net/manual/en/language.oop5.overloading.php
-[oop]: http://www.php.net/manual/en/language.oop5.php
-[anonymous-functions]: http://www.php.net/manual/en/functions.anonymous.php
-[closure-class]: http://php.net/manual/en/class.closure.php
-[callables]: http://php.net/manual/en/language.types.callable.php
-[magic-methods]: http://php.net/manual/en/language.oop5.magic.php
-[reflection]: http://www.php.net/manual/en/intro.reflection.php
+[namespaces]: http://php.net/manual/pt_BR/language.namespaces.php
+[overloading]: http://php.net/manual/pt_BR/language.oop5.overloading.php
+[oop]: http://www.php.net/manual/pt_BR/language.oop5.php
+[anonymous-functions]: http://www.php.net/manual/pt_BR/functions.anonymous.php
+[closure-class]: http://php.net/manual/pt_BR/class.closure.php
+[callables]: http://php.net/manual/pt_BR/language.types.callable.php
+[magic-methods]: http://php.net/manual/pt_BR/language.oop5.magic.php
+[reflection]: http://www.php.net/manual/pt_BR/intro.reflection.php
 [traits]: http://www.php.net/traits
-[call-user-func-array]: http://php.net/manual/en/function.call-user-func-array.php
+[call-user-func-array]: http://php.net/manual/pt_BR/function.call-user-func-array.php
 [closures-rfc]: https://wiki.php.net/rfc/closures

--- a/_posts/03-03-01-Namespaces.md
+++ b/_posts/03-03-01-Namespaces.md
@@ -24,5 +24,5 @@ padrão para arquivos, classes e namespaces, permitindo código plug-and-play.
 * [Leia sobre os Namespaces][namespaces]
 * [Leia sobre a PSR-0][psr0]
 
-[namespaces]: http://php.net/manual/en/language.namespaces.php
+[namespaces]: http://php.net/manual/pt_BR/language.namespaces.php
 [psr0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md

--- a/_posts/03-04-01-Standard-PHP-Library.md
+++ b/_posts/03-04-01-Standard-PHP-Library.md
@@ -13,4 +13,4 @@ implementem as interfaces SPL.
 
 * [Leia sobre a SPL][spl]
 
-[spl]: http://php.net/manual/en/book.spl.php 
+[spl]: http://php.net/manual/pt_BR/book.spl.php 

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -57,10 +57,10 @@ Hello, world
  * [Aprenda sobre como executar o PHP a partir da linha de comando][php-cli]
  * [Aprenda sobre como configurar o Windows para executar o PHP a partir da linha de comando][php-cli-windows]
 
-[phpinfo]: http://php.net/manual/en/function.phpinfo.php
-[cli-options]: http://www.php.net/manual/en/features.commandline.options.php
-[argc]: http://php.net/manual/en/reserved.variables.argc.php
-[argv]: http://php.net/manual/en/reserved.variables.argv.php
-[php-cli]: http://php.net/manual/en/features.commandline.php
-[php-cli-windows]: http://www.php.net/manual/en/install.windows.commandline.php
+[phpinfo]: http://php.net/manual/pt_BR/function.phpinfo.php
+[cli-options]: http://www.php.net/manual/pt_BR/features.commandline.options.php
+[argc]: http://php.net/manual/pt_BR/reserved.variables.argc.php
+[argv]: http://php.net/manual/pt_BR/reserved.variables.argv.php
+[php-cli]: http://php.net/manual/pt_BR/features.commandline.php
+[php-cli-windows]: http://www.php.net/manual/pt_BR/install.windows.commandline.php
 [exit-codes]: http://www.gsp.com/cgi-bin/man.cgi?section=3&topic=sysexits

--- a/_posts/04-03-01-PEAR.md
+++ b/_posts/04-03-01-PEAR.md
@@ -78,8 +78,8 @@ $request = new pear2\HTTP\Request();
 * [Aprenda mais sobre o uso do PEAR com Composer][6]
 
 [1]: http://pear.php.net/
-[2]: http://pear.php.net/manual/en/installation.getting.php
+[2]: http://pear.php.net/manual/pt_BR/installation.getting.php
 [3]: http://pear.php.net/packages.php
-[4]: http://pear.php.net/manual/en/guide.users.commandline.channels.php
+[4]: http://pear.php.net/manual/pt_BR/guide.users.commandline.channels.php
 [5]: /#composer_and_packagist
 [6]: http://getcomposer.org/doc/05-repositories.md#pear

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -64,5 +64,5 @@ foreach($periodIterator as $date)
 * [Leia sobre a DateTime][datetime]
 * [Leia sobre formatação de datas][dateformat] (opções aceitas para formatos de strings de data)
 
-[datetime]: http://www.php.net/manual/book.datetime.php
-[dateformat]: http://www.php.net/manual/function.date.php
+[datetime]: http://www.php.net/manual/pt_BR/book.datetime.php
+[dateformat]: http://www.php.net/manual/pt_BR/function.date.php

--- a/_posts/07-01-01-Databases.md
+++ b/_posts/07-01-01-Databases.md
@@ -23,7 +23,7 @@ substituir o uso do mysql pelo mysqli ou pela PDO na sua aplicação dentro de s
 assim você não terá que correr lá na frente. _Se você estiver começando do zero então não utilize de forma nenhuma a
 extensão mysql: use a [extensão MySQLi][mysqli], ou use a PDO._
 
-* [PHP: Choosing an API for MySQL](http://php.net/manual/en/mysqlinfo.api.choosing.php)
+* [PHP: Choosing an API for MySQL](http://php.net/manual/pt_BR/mysqlinfo.api.choosing.php)
 
 ## PDO
 
@@ -88,11 +88,11 @@ qualquer aplicação que você quiser:
 * [ZF2 Db][4]
 * [ZF1 Db][3]
 
-[1]: http://www.php.net/manual/en/book.pdo.php
+[1]: http://www.php.net/manual/pt_BR/book.pdo.php
 [2]: http://www.doctrine-project.org/projects/dbal.html
 [3]: http://framework.zend.com/manual/en/zend.db.html
 [4]: http://packages.zendframework.com/docs/latest/manual/en/index.html#zend-db
-[5]: http://php.net/manual/en/pdo.connections.php
+[5]: http://php.net/manual/pt_BR/pdo.connections.php
 [6]: https://github.com/auraphp/Aura.Sql
 
 [mysql]: http://uk.php.net/mysql

--- a/_posts/08-02-01-Errors.md
+++ b/_posts/08-02-01-Errors.md
@@ -10,4 +10,4 @@ O PHP possui vários níveis de severidade de erros. Os três tipos mais comuns 
 
 Um outro tipo de mensagem de erro reportada em tempo de compilação é o `E_STRICT`. Essas mensagens são usadas para sugerir mudanças no seu código para ajudar a garantir uma melhor interoperabilidade e compatibilidade do seu código.
 
-* [Constantes Pré-definidas para Tratamento de Erros](http://www.php.net/manual/en/errorfunc.constants.php)
+* [Constantes Pré-definidas para Tratamento de Erros](http://www.php.net/manual/pt_BR/errorfunc.constants.php)

--- a/_posts/08-03-01-Exceptions.md
+++ b/_posts/08-03-01-Exceptions.md
@@ -66,8 +66,8 @@ uma exceção padrão que seria muito vaga, ou criar uma exceção apenas para i
 * [Aninhando exceções no PHP][nesting-exceptions-in-php]
 * [Melhores práticas com exceções no PHP 5.3][exception-best-practices53]
 
-[exceptions]: http://php.net/manual/en/language.exceptions.php
-[splexe]: http://php.net/manual/en/spl.exceptions.php
+[exceptions]: http://php.net/manual/pt_BR/language.exceptions.php
+[splexe]: http://php.net/manual/pt_BR/spl.exceptions.php
 [splext]: /#standard_php_library
 [exception-best-practices53]: http://ralphschindler.com/2010/09/15/exception-best-practices-in-php-5-3
 [nesting-exceptions-in-php]: http://www.brandonsavage.net/exceptional-php-nesting-exceptions-in-php/

--- a/_posts/09-03-01-Password-Hashing.md
+++ b/_posts/09-03-01-Password-Hashing.md
@@ -45,7 +45,7 @@ if (password_verify('bad-password', $passwordHash)) {
 * [Aprenda sobre hashing no que diz respeito à criptografia] [3]
 * [PHP `password_hash` RFC] [4]
 
-[1]: http://us2.php.net/manual/en/function.password-hash.php
+[1]: http://us2.php.net/manual/pt_BR/function.password-hash.php
 [2]: https://github.com/ircmaxell/password_compat
 [3]: http://en.wikipedia.org/wiki/Cryptographic_hash_function
 [4]: https://wiki.php.net/rfc/password_hash

--- a/_posts/09-03-01-Password-Hashing.md
+++ b/_posts/09-03-01-Password-Hashing.md
@@ -45,7 +45,7 @@ if (password_verify('bad-password', $passwordHash)) {
 * [Aprenda sobre hashing no que diz respeito à criptografia] [3]
 * [PHP `password_hash` RFC] [4]
 
-[1]: http://us2.php.net/manual/pt_BR/function.password-hash.php
+[1]: http://php.net/manual/pt_BR/function.password-hash.php
 [2]: https://github.com/ircmaxell/password_compat
 [3]: http://en.wikipedia.org/wiki/Cryptographic_hash_function
 [4]: https://wiki.php.net/rfc/password_hash

--- a/_posts/09-04-01-Data-Filtering.md
+++ b/_posts/09-04-01-Data-Filtering.md
@@ -58,10 +58,10 @@ de email, um número de telefone ou uma idade quando for processar o envio de um
 
 [Veja sobre os Filtros de Validação][3]
 
-[1]: http://www.php.net/manual/en/book.filter.php
-[2]: http://www.php.net/manual/en/filter.filters.sanitize.php
-[3]: http://www.php.net/manual/en/filter.filters.validate.php
-[4]: http://php.net/manual/en/function.filter-var.php
-[5]: http://www.php.net/manual/en/function.filter-input.php
-[6]: http://php.net/manual/en/security.filesystem.nullbytes.php
+[1]: http://www.php.net/manual/pt_BR/book.filter.php
+[2]: http://www.php.net/manual/pt_BR/filter.filters.sanitize.php
+[3]: http://www.php.net/manual/pt_BR/filter.filters.validate.php
+[4]: http://php.net/manual/pt_BR/function.filter-var.php
+[5]: http://www.php.net/manual/pt_BR/function.filter-input.php
+[6]: http://php.net/manual/pt_BR/security.filesystem.nullbytes.php
 [html-purifier]: http://htmlpurifier.org/

--- a/_posts/09-04-01-Data-Filtering.md
+++ b/_posts/09-04-01-Data-Filtering.md
@@ -59,8 +59,8 @@ de email, um número de telefone ou uma idade quando for processar o envio de um
 [Veja sobre os Filtros de Validação][3]
 
 [1]: http://www.php.net/manual/pt_BR/book.filter.php
-[2]: http://www.php.net/manual/pt_BR/filter.filters.sanitize.php
-[3]: http://www.php.net/manual/pt_BR/filter.filters.validate.php
+[2]: http://www.php.net/manual/en/filter.filters.sanitize.php
+[3]: http://www.php.net/manual/en/filter.filters.validate.php
 [4]: http://php.net/manual/pt_BR/function.filter-var.php
 [5]: http://www.php.net/manual/pt_BR/function.filter-input.php
 [6]: http://php.net/manual/pt_BR/security.filesystem.nullbytes.php

--- a/_posts/09-06-01-Register-Globals.md
+++ b/_posts/09-06-01-Register-Globals.md
@@ -16,4 +16,4 @@ aplicação não pode dizer de forma efetiva de onde o dado está vindo.
 Por exemplo: `$_GET['foo']` poderia ficar disponível via `$foo`, o que poderia sobrescrever variáveis que não tiverem
 sido declaradas.  Se você estiver usando PHP < 5.4.0 __garanta__ que `register_globals` esteja __desligado__.
 
-* [Register_globals no manual do PHP](http://www.php.net/manual/en/security.globals.php)
+* [Register_globals no manual do PHP](http://www.php.net/manual/pt_BR/security.globals.php)

--- a/_posts/09-07-01-Error-Reporting.md
+++ b/_posts/09-07-01-Error-Reporting.md
@@ -45,6 +45,6 @@ Para esconder os erros no seu ambiente de <strong>produção</strong>, configure
 Com essas configurações em produção, os erros continuarão sendo registrados nos logs de erros do servidor web, mas
 eles não serão mostrados para o usuário. Para mais informações sobre essas configurações, veja o manual do PHP:
 
-* [Error_reporting](http://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting)
-* [Display_errors](http://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)
-* [Log_errors](http://www.php.net/manual/en/errorfunc.configuration.php#ini.log-errors)
+* [Error_reporting](http://www.php.net/manual/pt_BR/errorfunc.configuration.php#ini.error-reporting)
+* [Display_errors](http://www.php.net/manual/pt_BR/errorfunc.configuration.php#ini.display-errors)
+* [Log_errors](http://www.php.net/manual/pt_BR/errorfunc.configuration.php#ini.log-errors)

--- a/_posts/11-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/11-03-01-Virtual-or-Dedicated-Servers.md
@@ -17,7 +17,7 @@ muitas requisições concorrentes. Ele é importante especialmente em servidores
 sobrando.
 
 * [Leia mais sobre o nginx](http://nginx.org)
-* [Leia mais sobre o PHP-FPM](http://php.net/manual/en/install.fpm.php)
+* [Leia mais sobre o PHP-FPM](http://php.net/manual/pt_BR/install.fpm.php)
 * [Leia mais sobre como configurar de forma segura o nginx e o PHP-FPM](https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/)
 
 ### Apache e PHP

--- a/_posts/12-02-01-Bytecode-Cache.md
+++ b/_posts/12-02-01-Bytecode-Cache.md
@@ -18,7 +18,7 @@ No PHP 5.5 o OPcache foi incluído como um cache de bytecode nativo. Ele também
 
 Caches de bytecode populares são:
 
-* [APC](http://php.net/manual/en/book.apc.php)  (PHP 5.4 e anteriores)
+* [APC](http://php.net/manual/pt_BR/book.apc.php)  (PHP 5.4 e anteriores)
 * [XCache](http://xcache.lighttpd.net/)
 * [Zend Optimizer+](http://www.zend.com/products/server/) (parte do pacote Zend Server)
 * [WinCache](http://www.iis.net/download/wincacheforphp) (extensão para o MS Windows Server)

--- a/_posts/12-03-01-Object-Caching.md
+++ b/_posts/12-03-01-Object-Caching.md
@@ -56,8 +56,8 @@ como objetivo trazer o cache de objetos do APC para o PHP 5.5, já que o PHP ago
 Aprenda mais sobre sistemas populares de cache de objetos:
 
 * [APCu](https://github.com/krakjoe/apcu)
-* [Funções APC](http://php.net/manual/en/ref.apc.php)
+* [Funções APC](http://php.net/manual/pt_BR/ref.apc.php)
 * [Memcached](http://memcached.org/)
 * [Redis](http://redis.io/)
 * [XCache APIs](http://xcache.lighttpd.net/wiki/XcacheApi)
-* [Funções do WinCache](http://www.php.net/manual/en/ref.wincache.php)
+* [Funções do WinCache](http://www.php.net/manual/pt_BR/ref.wincache.php)

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -198,7 +198,7 @@ desenvolvedores possam facilmente adicionar novos tipos de saída sem que isso a
 
 Você pode ver como cada classe de saída concreta implementa a OutputInterface - isso serve a dois propósitos,
 primeiramente isso prevê um simples contrato que precisa ser obedecido por cada implementação concreta. Segundo, através
-da implementação de uma interface comum você verá na próxima seção que você pode utilizar [Indução de Tipo](http://php.net/manual/en/language.oop5.typehinting.php)
+da implementação de uma interface comum você verá na próxima seção que você pode utilizar [Indução de Tipo](http://php.net/manual/pt_BR/language.oop5.typehinting.php)
 para garantir que  o cliente que está utilizando esse comportamento é do tipo correto, nesse caso 'OutputInterface'.
 
 O próximo bloco de código demonstra como uma classe cliente relizando uma chamada deve usar um desses algorítimos e

--- a/pages/Functional-Programming.md
+++ b/pages/Functional-Programming.md
@@ -84,6 +84,6 @@ a função anônima for compilada.
 * [Mais detalhes em Closures RFC][closures-rfc]
 * [Leia sobre invocar dinamicamente funções com `call_user_func_array`][call-user-func-array]
 
-[anonymous-functions]: http://www.php.net/manual/en/functions.anonymous.php
-[call-user-func-array]: http://php.net/manual/en/function.call-user-func-array.php
+[anonymous-functions]: http://www.php.net/manual/pt_BR/functions.anonymous.php
+[call-user-func-array]: http://php.net/manual/pt_BR/function.call-user-func-array.php
 [closures-rfc]: https://wiki.php.net/rfc/closures

--- a/pages/The-Basics.md
+++ b/pages/The-Basics.md
@@ -33,8 +33,8 @@ if (strpos('testing', 'test') !== false) {    // true, já que uma comparação 
 }
 {% endhighlight %}
 
-* [Operadores de Comparação](http://php.net/manual/en/language.operators.comparison.php)
-* [Tabela de Comparação](http://php.net/manual/en/types.comparisons.php)
+* [Operadores de Comparação](http://php.net/manual/pt_BR/language.operators.comparison.php)
+* [Tabela de Comparação](http://php.net/manual/pt_BR/types.comparisons.php)
 
 ## Estrutura de Controle
 
@@ -67,7 +67,7 @@ function test($a)
 }
 {% endhighlight %}
 
-* [Estrutura Condicionais](http://php.net/manual/en/control-structures.if.php)
+* [Estrutura Condicionais](http://php.net/manual/pt_BR/control-structures.if.php)
 
 ### Estruturas de Decisão
 
@@ -101,7 +101,7 @@ function test($a)
 }
 {% endhighlight %}
 
-* [Estruturas de Decisão](http://php.net/manual/en/control-structures.switch.php)
+* [Estruturas de Decisão](http://php.net/manual/pt_BR/control-structures.switch.php)
 * [PHP Switch](http://phpswitch.com/)
 
 ## Namespace Global
@@ -126,8 +126,8 @@ function array()
 }
 {% endhighlight %}
 
-* [Espaço Global](http://php.net/manual/en/language.namespaces.global.php)
-* [Regras Globais](http://php.net/manual/en/userlandnaming.rules.php)
+* [Espaço Global](http://php.net/manual/pt_BR/language.namespaces.global.php)
+* [Regras Globais](http://php.net/manual/pt_BR/userlandnaming.rules.php)
 
 ## Strings
 
@@ -151,7 +151,7 @@ $a = 'Multi-line example'      // operador de concatenação (.)
     . 'of what to do';
 {% endhighlight %}
 
-* [Operadores de Strings](http://php.net/manual/en/language.operators.string.php)
+* [Operadores de Strings](http://php.net/manual/pt_BR/language.operators.string.php)
 
 ### Tipos de Strings
 
@@ -177,7 +177,7 @@ echo 'Essa é minha string, veja como ela é bonita.';    // sem necessidade de 
  */
 {% endhighlight %}
 
-* [Aspas Simples](http://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.single)
+* [Aspas Simples](http://www.php.net/manual/pt_BR/language.types.string.php#language.types.string.syntax.single)
 
 #### Aspas Duplas
 
@@ -222,7 +222,7 @@ $juice = array('maça', 'laranja', 'ameixa');
 echo "Eu bebi suco feito de {$juice[1]}s";   // $juice[1] será interpretado
 {% endhighlight %}
 
-* [Aspas Duplas](http://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.double)
+* [Aspas Duplas](http://www.php.net/manual/pt_BR/language.types.string.php#language.types.string.syntax.double)
 
 #### Sintaxe Nowdoc
 
@@ -248,7 +248,7 @@ EOD;                        // fechando 'EOD' precisa estar na sua própria linh
  */
 {% endhighlight %}
 
-* [Sintaxe Nowdoc](http://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.nowdoc)
+* [Sintaxe Nowdoc](http://www.php.net/manual/pt_BR/language.types.string.php#language.types.string.syntax.nowdoc)
 
 #### Sintaxe Heredoc
 
@@ -276,7 +276,7 @@ EOD;                        // closing 'EOD' must be on it's own line, and to th
  */
 {% endhighlight %}
 
-* [Sintaxe Heredoc](http://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc)
+* [Sintaxe Heredoc](http://www.php.net/manual/pt_BR/language.types.string.php#language.types.string.syntax.heredoc)
 
 ## Operadores Ternários
 
@@ -308,7 +308,7 @@ $a = 5;
 return ($a == 5) ? 'yay' : 'nope';    // esse exemplo irá retornar 'yay'
 {% endhighlight %}
 
-* [Operadores Ternários](http://php.net/manual/en/language.operators.comparison.php)
+* [Operadores Ternários](http://php.net/manual/pt_BR/language.operators.comparison.php)
 
 ## Declaração de Variáveis
 


### PR DESCRIPTION
@rogeriopradoj @klaussilveira @pauloelr 

Faz total sentido que na versão `pt_BR` do phptherightway os links para o manual do PHP redirecionem o usuário para a versão `pt_BR` do manual.

Alguns arquivos da versão `en` ainda não existem na versão `pt_BR` e então eu precisei revertê-los para os manter apontando para a versão `en` original.
