### PR TITLE
URL 404 Leia sobre os Padrões de Código da Zend

### DIFF
--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -47,7 +47,7 @@ possam trabalhar nessa base de código.
 [psr2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 [psr4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 [pear-cs]: http://pear.php.net/manual/en/standards.php
-[zend-cs]: http://framework.zend.com/wiki/display/ZFDEV2/Coding+Standards
+[zend-cs]: http://framework.zend.com/manual/current/en/ref/coding.standard.html
 [symfony-cs]: http://symfony.com/doc/current/contributing/code/standards.html
 [phpcs]: http://pear.php.net/package/PHP_CodeSniffer/
 [st-cs]: https://github.com/benmatselby/sublime-phpcs


### PR DESCRIPTION
a URL que está no existe por isto troquei para a seguinte URL http://framework.zend.com/manual/current/en/ref/coding.standard.html
