### PR TITLE
Atualização de links quebrados no site traduzido

### DIFF
--- a/_posts/12-02-01-Platform-as-a-Service.md
+++ b/_posts/12-02-01-Platform-as-a-Service.md
@@ -10,5 +10,5 @@ O PaaS fornece o sistema e a arquitetura de rede necessários para executar apli
 precisar de quase nenhuma configuração para publicar aplicações ou frameworks PHP.
 
 Recentemente o PaaS se tornou um método popular para publicar, hospedar e escalar aplicações PHP de todos os tamanho
-. Você pode encontrar uma lista de [fornecedores de PHP PaaS "Platform as a Service"](#php_paas_providers) na
-[seção sobre recursos](#resources).
+. Você pode encontrar uma lista de [fornecedores de PHP PaaS "Platform as a Service"](#plataforma_como_servico_paas) na
+[seção sobre recursos](#recursos).

--- a/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
@@ -11,7 +11,7 @@ servidores virtuais ou dedicados te dão controle completo do ambiente de produ�
 
 ### nginx e PHP-FPM
 
-O PHP, por meio do seu Gerenciador de Processos FastCGI (FPM), funciona muito bem junto com o [nginx](http://nginx.or),
+O PHP, por meio do seu Gerenciador de Processos FastCGI (FPM), funciona muito bem junto com o [nginx](https://nginx.org),
 que é um servidor web leve e de alta performance. Ele usa menos memória do que o Apache e pode lidar melhor como
 muitas requisições concorrentes. Ele é importante especialmente em servidores virtuais que não tem muita memória
 sobrando.
@@ -35,11 +35,11 @@ profundamente nos aspectos de administração do servidor. Observe que, se você
 MPM.
 
 Alternativamente, se você quiser extrair mais performance e estabilidade do seu Apache então você poderia se
-beneficiar do mesmo sistema FPM que o nginx e executar o [worker MPM](http://httpd.apache.org/docs/2.4/mod/worker.htm)
+beneficiar do mesmo sistema FPM que o nginx e executar o [worker MPM](http://httpd.apache.org/docs/2.4/mod/worker.html)
 ou o [event MPM](http://httpd.apache.org/docs/2.4/mod/event.html) com o mod_fastcgi ou com o mod_fcgi. Essa
 configuração será significativamente mais eficiente em relação a memória e muito mais rápida, mas gera mais trabalho.
 
 * [Leia mais sobre o Apache](http://httpd.apache.org/)
 * [Leia mais sobre os Multi-Processing Modules](http://httpd.apache.org/docs/2.4/mod/mpm_common.html)
-* [Leia mais sobre o mod_fastcgi](http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html)
+* [Leia mais sobre o mod_fastcgi](https://blogs.oracle.com/opal/php-fpm-fastcgi-process-manager-with-apache-2)
 * [Leia mais sobre o mod_fcgid](http://httpd.apache.org/mod_fcgid/)

--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -35,13 +35,10 @@ pode controlar os processos de empacotamento, implementação e testes através 
 baseado em [Apache Ant](http://ant.apache.org/)) fornece um rico conjunto de tarefas geralmente necessárias para 
 instalar ou atualizar uma aplicação web e pode ser estendido com tarefas adicionais personalizadas, escritas em PHP.
 
-[Capistrano](https://github.com/capistrano/capistrano/wiki) é um sistema para *programadores intermediarios ou
+[Capistrano](https://capistranorb.com/) é um sistema para *programadores intermediarios ou
 avançados* que executa comando de forma estruturada e repetitiva em uma ou mais maquinas. Ele é pré-configurado para
 implementar aplicações Ruby on Rails, entretanto pessoas estão **implementando com sucesso sistemas em PHP** com ele.
 Ter sucesso com uso de Capistrano depende de um conhecimento de trabalho com Ruby e Rails.
-
-O artigo de Dave Gardner [PHP Deployment com Capistrano](http://www.davegardner.me.uk/blog/2012/02/13/php-deployment-with-capistrano/)
-é um bom ponto de partida para desenvolvedores PHP interessando em Capistrano.
 
 [Chef](http://www.opscode.com/chef/) é mais que um framework de implementação, é um framework de integração bastante
 poderoso escrito em Ruby que não consegue apenas implementar sua aplicação mas também construir seu ambiente de servidor
@@ -51,7 +48,7 @@ Conteúdo sobre Chef para Desenvolvedores PHP:
 
 * [Serie em 3 partes sobre implementação de uma aplicação LAMP com Chef, Vagrant, e EC2](http://www.jasongrimes.org/2012/06/managing-lamp-environments-with-chef-vagrant-and-ec2-1-of-3/)
 * [Chef Cookbook sobre instalação e configuração de PHP 5.3 e do sistema de gerenciamento de pacotes PEAR](https://github.com/opscode-cookbooks/php)
-* [Chef - série de video tutoriais por Opscode, os criadores do chef](https://www.youtube.com/playlist?list=PLrmstJpucjzWKt1eWLv88ZFY4R1jW8amR)
+* [Chef - série de video tutoriais por Opscode, os criadores do chef](https://www.youtube.com/playlist?list=PL11cZfNdwNyPnZA9D1MbVqldGuOWqbumZ)
 
 Leitura Adicional:
 

--- a/_posts/13-03-01-Docker.md
+++ b/_posts/13-03-01-Docker.md
@@ -46,4 +46,4 @@ Como fazer isso está bem descrito no [Guia do Usuário Docker][docker-doc].
 [docker]: http://docker.com/
 [docker-hub]: https://registry.hub.docker.com/
 [docker-install]: https://docs.docker.com/installation/
-[docker-doc]: https://docs.docker.com/userguide/
+[docker-doc]: https://docs.docker.com/get-started/

--- a/_posts/15-01-01-Resources.md
+++ b/_posts/15-01-01-Resources.md
@@ -28,16 +28,19 @@ anchor: recursos
 
 ## Fornecedores de PaaS PHP
 
-* [PagodaBox](https://pagodabox.com/)
-* [AppFog](https://appfog.com/)
-* [Heroku](https://heroku.com)
-* [fortrabbit](http://fortrabbit.com/)
-* [Engine Yard Cloud](https://www.engineyard.com/products/cloud)
-* [Red Hat OpenShift Platform](http://www.redhat.com/products/cloud-computing/openshift/)
-* [dotCloud](http://docs.dotcloud.com/services/php/)
-* [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/)
-* [cloudControl](https://www.cloudcontrol.com/)
-* [Windows Azure](http://www.windowsazure.com/)
-* [Zend Developer Cloud](http://www.phpcloud.com/develop)
-* [Google App Engine](https://developers.google.com/appengine/docs/php/gettingstarted/)
-* [Jelastic](http://jelastic.com/)
+* [AppFog](https://www.ctl.io/appfog/)
+* [AWS Elastic Beanstalk](https://aws.amazon.com/pt/elasticbeanstalk/)
+* [Cloudways](https://www.cloudways.com/br/)
+* [Engine Yard Cloud](https://www.engineyard.com/features)
+* [fortrabbit](https://fortrabbit.com/)
+* [Google App Engine](https://cloud.google.com/appengine/docs/php/)
+* [Heroku](https://devcenter.heroku.com/categories/php-support)
+* [IBM Cloud](https://cloud.ibm.com/docs/runtimes/php?topic=PHP-getting_started#getting_started)
+* [Jelastic](https://jelastic.com/)
+* [Microsoft Azure](https://azure.microsoft.com/pt-br/)
+* [Nanobox](https://nanobox.io/)
+* [Pivotal Web Services](https://run.pivotal.io/)
+* [Platform.sh](https://platform.sh/)
+* [Red Hat OpenShift](https://www.openshift.com/)
+
+Para verificar quais versões estão disponíveis nestes provedores de PaaS, vá para [Versões PHP](http://phpversions.info/paas-hosting/).

--- a/_posts/15-01-01-Resources.md
+++ b/_posts/15-01-01-Resources.md
@@ -24,7 +24,7 @@ anchor: recursos
 
 ## Mentoring
 
-* [phpmentoring.org](http://phpmentoring.org/) - Mentoring formal e `pessoa-para-pessoa` na comunidade PHP.
+* [php-mentoring.org](https://php-mentoring.org/) - Mentoria formal e `pessoa-para-pessoa` na comunidade PHP.
 
 ## Fornecedores de PaaS PHP
 


### PR DESCRIPTION
Atualização da sessão "mentoring" e "fornecedores de PaaS" contendo:
- Atualização de links quebrados/alterados;
- Atualização da lista de fornecedores em ordem alfabética;
- Remoção dos provedores que não estão mais listados no site em inglês: https://phptherightway.com/#php_paas_providers ;
- Adição do link onde é possível verificar as versões de php que os provedores PaaS estão servindo.